### PR TITLE
Remove Supporting Service Limit

### DIFF
--- a/api/config/credentials/azure/azure_credentials.go
+++ b/api/config/credentials/azure/azure_credentials.go
@@ -74,7 +74,6 @@ func (ac *AzureCredentials) Schema() map[string]*hcl.Schema {
 			Type:        hcl.TypeList,
 			Description: "A list of Azure supporting services to be monitored. For each service there's a sublist of its metrics and the metrics' dimensions that should be monitored. All of these elements (services, metrics, dimensions) must have corresponding static definitions on the server.",
 			Optional:    true,
-			MaxItems:    10,
 			Elem: &hcl.Resource{
 				Schema: new(AzureSupportingService).Schema(),
 			},


### PR DESCRIPTION
Basically the Azure equivalent of https://github.com/dynatrace-oss/terraform-provider-dynatrace/issues/73

When adding more than 10 supporting services, the underlying Dynatrace GO code gives this error, this is a super quick fix

(Question for whoever manages this, should I also make a pr upstream with the go SHA? e.g. https://github.com/dynatrace-oss/terraform-provider-dynatrace/commit/ce510755e40147ef81051ad5aab4cb27ab1e3f7a