### PR TITLE
fix: Improve the description of the field 'service' in keyrequests provider

### DIFF
--- a/api/config/v2/keyrequests/key_request.go
+++ b/api/config/v2/keyrequests/key_request.go
@@ -15,7 +15,7 @@ func (me *KeyRequest) Schema() map[string]*hcl.Schema {
 		"service": {
 			Type:        hcl.TypeString,
 			Required:    true,
-			Description: "Whether to create an entry point or not",
+			Description: "ID of Dynatrace Service, eg. SERVICE-123ABC45678EFGH",
 		},
 		"names": {
 			Type:        hcl.TypeSet,


### PR DESCRIPTION
`api/v2/keyrequests` provider has wrong/misleading description fixed